### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Assets/Importer/panda.prefab
+++ b/Assets/Importer/panda.prefab
@@ -215,7 +215,7 @@
                     }
                 },
                 "Component_[7129885340583146507]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7129885340583146507,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -378,7 +378,7 @@
             "Name": "panda_link3",
             "Components": {
                 "Component_[11727172097126435982]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 11727172097126435982,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -824,7 +824,7 @@
                     "Id": 15888283843276217511
                 },
                 "Component_[17783744754927152065]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17783744754927152065,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1076,7 +1076,7 @@
                     "Id": 4068300133305965099
                 },
                 "Component_[4583303953242386342]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4583303953242386342,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1593,7 +1593,7 @@
                     }
                 },
                 "Component_[1845866248095674128]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1845866248095674128,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1851,7 +1851,7 @@
                     ]
                 },
                 "Component_[7816217204977771734]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7816217204977771734,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1969,7 +1969,7 @@
                     "Id": 12542366717714580296
                 },
                 "Component_[1642651622480229913]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1642651622480229913,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -2312,7 +2312,7 @@
                     }
                 },
                 "Component_[7651470095727410225]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7651470095727410225,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -2454,7 +2454,7 @@
                     "Id": 1903930015834931168
                 },
                 "Component_[2188957055815424499]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2188957055815424499,
                     "ColliderConfiguration": {
                         "Rotation": [

--- a/Levels/GripperTest/GripperTest.prefab
+++ b/Levels/GripperTest/GripperTest.prefab
@@ -670,7 +670,7 @@
                     "Id": 16645264286634162051
                 },
                 "Component_[5282319161955034077]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 5282319161955034077,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -744,7 +744,7 @@
             "Name": "panda_hand",
             "Components": {
                 "Component_[12527173394158692186]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12527173394158692186,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1130,7 +1130,7 @@
                     "Id": 1903930015834931168
                 },
                 "Component_[2188957055815424499]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2188957055815424499,
                     "ColliderConfiguration": {
                         "Rotation": [
@@ -1315,7 +1315,7 @@
                     "Id": 12542366717714580296
                 },
                 "Component_[1642651622480229913]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1642651622480229913,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Levels/mobile_robot_physics/mobile_robot_physics.prefab
+++ b/Levels/mobile_robot_physics/mobile_robot_physics.prefab
@@ -1442,7 +1442,7 @@
                     }
                 },
                 "Component_[13632494578845322196]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13632494578845322196,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -4374,7 +4374,7 @@
                     "Id": 16787872766302325326
                 },
                 "Component_[17319527509850424042]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 17319527509850424042,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -4827,7 +4827,7 @@
                     "Id": 5154916986803806312
                 },
                 "Component_[6345713874119317736]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6345713874119317736,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -4957,7 +4957,7 @@
                     ]
                 },
                 "Component_[3933878623927137301]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3933878623927137301,
                     "ColliderConfiguration": {
                         "MaterialSlots": {


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. 
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor. 
Opened `mobile_robot_physics` level and moved the vehicle around.

Signed-off-by: moraaar <moraaar@amazon.com>